### PR TITLE
Train output folder defined in train step

### DIFF
--- a/azure/train_pipeline.ipynb
+++ b/azure/train_pipeline.ipynb
@@ -93,11 +93,10 @@
     "    datastore=water_blob_ds,\n",
     "    data_reference_name=\"preprocessed_datasets\",\n",
     "    path_on_datastore=\"preprocessed_data/\")\n",
-    "outputs_dir = \"outputs/\" + datetime.datetime.now().strftime(\"%Y%m%d-%H%M%S\") + '/'  # All outputs from this run go in a new folder\n",
     "outputs_dr = DataReference(\n",
     "    datastore=water_blob_ds,\n",
     "    data_reference_name=\"outputs\",\n",
-    "    path_on_datastore=outputs_dir)\n",
+    "    path_on_datastore=\"outputs/\")\n",
     "\n",
     "# Set up references to pipeline data (intermediate pipeline storage)\n",
     "preprocessed_data_pd = PipelineData(\n",
@@ -266,7 +265,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/azure/train_step/train_step.py
+++ b/azure/train_step/train_step.py
@@ -2,6 +2,7 @@ import os
 import argparse
 import yaml
 import shutil
+import datetime
 from azureml.core import Run
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail
@@ -18,7 +19,7 @@ args = parser.parse_args()
 run = Run.get_context()
 
 # All outputs from this run will be in the same directory
-DESTINATION_DIR = args.trainoutputdir
+DESTINATION_DIR = args.trainoutputdir + datetime.datetime.now().strftime("%Y%m%d-%H%M%S") + '/' # All outputs from this run go in a new folder
 if not os.path.exists(DESTINATION_DIR):
     os.makedirs(DESTINATION_DIR)
 


### PR DESCRIPTION
An issue was discovered when running the training pipeline in production regarding the saving of final results. The training output directory was being defined in the training pipeline's notebook instead of in the train step itself. As a result, the pipeline was attempting to save training outputs in a preexisting folder, which triggered an error in _shutil.move()_. This was fixed by creating the training output directory for the run in _train_step.py_ instead of in _train_pipeline.ipynb_.