### PR TITLE
Pipeline forecast range changed to 20 years

### DIFF
--- a/azure/train_pipeline.ipynb
+++ b/azure/train_pipeline.ipynb
@@ -159,7 +159,7 @@
    "source": [
     "# Define some constants\n",
     "TEST_DAYS = 183                # Test trained model on most recent half year\n",
-    "FORECAST_DAYS = 4 * 365 + 1    # Obtain forecast for the next 4 years\n",
+    "FORECAST_DAYS = 20 * 365 + 5    # Obtain forecast for the next 20 years\n",
     "PREPROCESS_STRATEGY = 'quick'  # Set to 'complete' to loop over all consumption data. Set to 'quick' to preprocess newly uploaded data and append to old preprocessed data.\n",
     "EXPERIMENT_NAME = 'Train-Forecast-Experiment-v2'\n",
     "\n",


### PR DESCRIPTION
The forecast range was extended to 20 years for models trained using the training pipeline.